### PR TITLE
Fixes conflicting comments about the result timestamp.

### DIFF
--- a/AFBR-S50/Include/api/argus_res.h
+++ b/AFBR-S50/Include/api/argus_res.h
@@ -220,7 +220,7 @@ typedef struct argus_results_t
      *   - < 0 for errors and invalid measurement signal. */
     status_t Status;
 
-    /*! Time in milliseconds (measured since the last MCU startup/reset)
+    /*! Time in seconds and microseconds (measured since the last MCU startup/reset)
      *  when the measurement was triggered. */
     ltc_t TimeStamp;
 


### PR DESCRIPTION
I'm currently making a [complete ROS 2 interface](https://github.com/CogniPilot/afbr_msgs) and realized that the [timestamp is not in millisecond](https://github.com/Broadcom/AFBR-S50-API/blob/a1551ff147b54065858f3d6e8e3add390f15e414/AFBR-S50/Include/api/argus_res.h#L223) basis but [actually microsecond](https://github.com/Broadcom/AFBR-S50-API/blob/a1551ff147b54065858f3d6e8e3add390f15e414/AFBR-S50/Include/utility/time.h#L76).

This is a minor fix to simply reflect that and match what we have here: https://github.com/CogniPilot/afbr_msgs/commit/7b5e48951e4b24424781de743f7b57cb20687575